### PR TITLE
Added layouts import and export commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ WP-CLI commands for Toolset plugins.
    
 ## Documentation
 
-At the moment, three top-level commands are available. Feel free to explore
+At the moment, four top-level commands are available. Feel free to explore
 them and all their available subcommands here:
 
 - [wp toolset](docs/toolset.md)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ them and all their available subcommands here:
 - [wp toolset](docs/toolset.md)
 - [wp types](docs/types.md)
 - [wp views](docs/views.md)
+- [wp layouts](docs/layouts.md)
 
 Of course, when installed, the same information will be available via the `wp help` command.
 

--- a/application/Bootstrap.php
+++ b/application/Bootstrap.php
@@ -15,6 +15,7 @@ use OTGS\Toolset\CLI\Types\FieldGroup;
 use OTGS\Toolset\CLI\Types\PostType;
 use OTGS\Toolset\CLI\Types\Types;
 use OTGS\Toolset\CLI\Commands\Toolset\Relationships;
+use OTGS\Toolset\CLI\Layouts\LayoutsExport;
 use WP_CLI;
 use OTGS\Toolset\CLI\Views\Export;
 
@@ -46,6 +47,9 @@ class Bootstrap {
 			'template' => CT::class,
 			'export' => Export::class,
 			'import' => Views\Import::class,
+		],
+		'layouts' => [
+			'export' => LayoutsExport::class,
 		],
 		'post' => [
 			'post' => Extra::class,
@@ -141,6 +145,8 @@ class Bootstrap {
 				return ( apply_filters( 'toolset_is_wpml_active_and_configured', false ) );
 			case 'toolset':
 				return apply_filters( 'types_is_active', false ) || $this->is_plugin_active( 'views' );
+			case 'layouts':
+				return true ; // FIXME: do we need a real check here?
 			case 'csv':
 				return true;
 			default:

--- a/application/Bootstrap.php
+++ b/application/Bootstrap.php
@@ -46,12 +46,12 @@ class Bootstrap {
 			'archive' => WPA::class,
 			'view' => View::class,
 			'template' => CT::class,
-			'export' => Export::class,
+			'export' => Views\Export::class,
 			'import' => Views\Import::class,
 		],
 		'layouts' => [
-			'export' => LayoutsExport::class,
-			'import' => LayoutsImport::class,
+			'export' => Layouts\Export::class,
+			'import' => Layouts\Import::class,
 		],
 		'post' => [
 			'post' => Extra::class,
@@ -148,7 +148,7 @@ class Bootstrap {
 			case 'toolset':
 				return apply_filters( 'types_is_active', false ) || $this->is_plugin_active( 'views' );
 			case 'layouts':
-				return true ; // FIXME: do we need a real check here?
+				return defined( 'WPDDL_DEVELOPMENT' ) || defined( 'WPDDL_PRODUCTION' );
 			case 'csv':
 				return true;
 			default:

--- a/application/Bootstrap.php
+++ b/application/Bootstrap.php
@@ -15,6 +15,7 @@ use OTGS\Toolset\CLI\Types\FieldGroup;
 use OTGS\Toolset\CLI\Types\PostType;
 use OTGS\Toolset\CLI\Types\Types;
 use OTGS\Toolset\CLI\Commands\Toolset\Relationships;
+use OTGS\Toolset\CLI\Layouts\LayoutsImport;
 use OTGS\Toolset\CLI\Layouts\LayoutsExport;
 use WP_CLI;
 use OTGS\Toolset\CLI\Views\Export;
@@ -50,6 +51,7 @@ class Bootstrap {
 		],
 		'layouts' => [
 			'export' => LayoutsExport::class,
+			'import' => LayoutsImport::class,
 		],
 		'post' => [
 			'post' => Extra::class,

--- a/application/Commands/Layouts/Export.php
+++ b/application/Commands/Layouts/Export.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace OTGS\Toolset\CLI\Layouts;
+
+use WPDD_Layouts_Theme ;
+use ZIP ;
+
+/*
+ * FIXME: replace \WP_CLI with WpCli.
+ */
+
+/**
+ * Layouts export command.
+ */
+class LayoutsExport extends LayoutsCommand {
+
+	/**
+	 * Exports Layouts to a ZIP file.
+	 *
+	 * ## Options
+	 *
+	 * [--overwrite]
+	 * : Overwrite existing ZIP file.
+	 *
+	 * <file>
+	 * : The path of the exported ZIP file.
+	 *
+	 * ## Examples
+	 *
+	 *     wp layouts export <file>
+	 *
+	 * @param array $args The array of command-line arguments.
+	 * @param array $assoc_args The associative array of command-line options.
+	 */
+
+	public function __invoke( $args, $assoc_args ) {
+
+		list( $export_filename ) = $args;
+
+		if ( empty ( $export_filename ) ) {
+			\WP_CLI::warning( __( 'You must specify a valid file.', 'toolset-cli' ) );
+			return;
+		}
+
+		// Does the specified filename have a ".zip" extension? If not, add it and notify the user.
+		// Returns filename extension without a period prefixed to it.
+		$export_filename_extension = pathinfo( $export_filename, PATHINFO_EXTENSION );
+
+		if ( ! $export_filename_extension || strtolower ( $export_filename_extension ) != 'zip' ) {
+			// Returns filename without the path to the parent directory.
+			$export_filename_basename = pathinfo( $export_filename, PATHINFO_BASENAME );
+
+			\WP_CLI::warning ( __( sprintf ('"%1$s" lacks a ".zip" extension. Adding it. The new filename will be "%1$s.zip."', $export_filename_basename ), 'toolset-cli' ) ) ;
+
+			// Append '.zip' to export filename.
+			$export_filename .= '.zip' ;
+		}
+
+		$overwrite_export_filename = false ;
+		// Parse command-line options.
+		if ( count ( $assoc_args ) > 0 ) {
+			if ( isset ( $assoc_args['overwrite'] ) ) {
+				$overwrite_export_filename = true ;
+			}
+		}
+
+		// Abort if the file already exists and we are not deliberately overwriting it.
+		if ( file_exists ( $export_filename ) && ! $overwrite_export_filename ) {
+			\WP_CLI::error( __( sprintf ('"%1$s" already exists. Aborting. (Use "--overwrite" to overwrite %1$s.)', $export_filename), 'toolset-cli' ) );
+		}
+
+		// Load the export code from the Layouts plugin.
+		require_once WPDDL_ABSPATH . '/inc/theme/wpddl.theme-support.class.php' ;
+
+		$layouts = new WPDD_Layouts_Theme () ;
+		$layouts_data = $layouts->export_for_download() ;
+		// The "parent" folder holding the layouts files, when unzipped.
+		$directory_name = pathinfo( $export_filename, PATHINFO_FILENAME );
+
+		$export_status = false ;
+		if (class_exists('Zip')) {
+			$zip = new Zip();
+			$zip->addDirectory( $directory_name );
+
+			foreach ( $layouts_data as $file_data ) {
+				$zip->addFile( $file_data['file_data'], $directory_name . '/' . $file_data['file_name'] );
+			}
+
+			if ( file_put_contents ( $export_filename, $zip->getZipData() ) ) {
+				$export_status = true ;
+			}
+
+		}
+		else {
+			\WP_CLI::error ( 'The ZIP library is not present. Aborting.', 'toolset-cli' ) ;
+		}
+
+		if ( $export_status === true ) {
+			\WP_CLI::success( sprintf ( __( 'The layouts were exported successfully to "%s."'), $export_filename ), 'toolset-cli' );
+		} else {
+			\WP_CLI::error( __( 'There was an error exporting the layouts.', 'toolset-cli' ) );
+		}
+
+	}
+
+}

--- a/application/Commands/Layouts/Export.php
+++ b/application/Commands/Layouts/Export.php
@@ -5,14 +5,10 @@ namespace OTGS\Toolset\CLI\Layouts;
 use WPDD_Layouts_Theme ;
 use ZIP ;
 
-/*
- * FIXME: replace \WP_CLI with WpCli.
- */
-
 /**
  * Layouts export command.
  */
-class LayoutsExport extends LayoutsCommand {
+class Export extends LayoutsCommand {
 
 	/**
 	 * Exports Layouts to a ZIP file.
@@ -32,14 +28,12 @@ class LayoutsExport extends LayoutsCommand {
 	 * @param array $args The array of command-line arguments.
 	 * @param array $assoc_args The associative array of command-line options.
 	 */
-
 	public function __invoke( $args, $assoc_args ) {
 
 		list( $export_filename ) = $args;
 
 		if ( empty ( $export_filename ) ) {
-			\WP_CLI::warning( __( 'You must specify a valid file.', 'toolset-cli' ) );
-			return;
+			$this->wp_cli()->error( __( 'You must specify a valid file.', 'toolset-cli' ) );
 		}
 
 		// Does the specified filename have a ".zip" extension? If not, add it and notify the user.
@@ -50,7 +44,7 @@ class LayoutsExport extends LayoutsCommand {
 			// Returns filename without the path to the parent directory.
 			$export_filename_basename = pathinfo( $export_filename, PATHINFO_BASENAME );
 
-			\WP_CLI::warning ( __( sprintf ('"%1$s" lacks a ".zip" extension. Adding it. The new filename will be "%1$s.zip."', $export_filename_basename ), 'toolset-cli' ) ) ;
+			$this->wp_cli()->warning ( __( sprintf ('"%1$s" lacks a ".zip" extension. Adding it. The new filename will be "%1$s.zip."', $export_filename_basename ), 'toolset-cli' ) ) ;
 
 			// Append '.zip' to export filename.
 			$export_filename .= '.zip' ;
@@ -66,7 +60,7 @@ class LayoutsExport extends LayoutsCommand {
 
 		// Abort if the file already exists and we are not deliberately overwriting it.
 		if ( file_exists ( $export_filename ) && ! $overwrite_export_filename ) {
-			\WP_CLI::error( __( sprintf ('"%1$s" already exists. Aborting. (Use "--overwrite" to overwrite %1$s.)', $export_filename), 'toolset-cli' ) );
+			$this->wp_cli()->error( __( sprintf ('"%1$s" already exists. Aborting. (Use "--overwrite" to overwrite %1$s.)', $export_filename), 'toolset-cli' ) );
 		}
 
 		// Load the export code from the Layouts plugin.
@@ -92,13 +86,13 @@ class LayoutsExport extends LayoutsCommand {
 
 		}
 		else {
-			\WP_CLI::error ( 'The ZIP library is not present. Aborting.', 'toolset-cli' ) ;
+			$this->wp_cli()->error ( __( 'The ZIP library is not present. Aborting.', 'toolset-cli' ) ) ;
 		}
 
 		if ( $export_status === true ) {
-			\WP_CLI::success( sprintf ( __( 'The layouts were exported successfully to "%s."'), $export_filename ), 'toolset-cli' );
+			$this->wp_cli()->success( sprintf ( __( 'The layouts were exported successfully to "%s."'), $export_filename ), 'toolset-cli' );
 		} else {
-			\WP_CLI::error( __( 'There was an error exporting the layouts.', 'toolset-cli' ) );
+			$this->wp_cli()->error( __( 'There was an error exporting the layouts.', 'toolset-cli' ) );
 		}
 
 	}

--- a/application/Commands/Layouts/Import.php
+++ b/application/Commands/Layouts/Import.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace OTGS\Toolset\CLI\Layouts;
+
+use WPDD_Layouts_Theme ;
+
+/*
+ * FIXME: replace \WP_CLI with WpCli.
+ */
+
+/**
+ * Layouts import command.
+ */
+class LayoutsImport extends LayoutsCommand {
+
+	/**
+	 * Imports Layouts from a ZIP file.
+	 *
+	 * Omitted options default to 'false'.
+	 *
+	 * ## Options
+	 *
+	 * [--layouts-overwrite]
+	 * : Overwrite any layout if it already exists.
+	 *
+	 * [--layouts-delete]
+	 * : Delete any existing layouts that are not in the import.
+	 *
+	 * [--overwrite-layouts-assignment]
+	 * : Overwrite layout assignments.
+	 *
+	 * <file>
+	 * : The path to the ZIP file to import.
+	 *
+	 * ## Examples
+	 *
+	 *     wp layouts import <file>
+	 *     wp layouts import --layouts-overwrite --layouts-delete --overwrite-layouts-assignment <file>
+	 *
+	 * @param array $args The array of command-line arguments.
+	 * @param array $assoc_args The associative array of command-line options.
+	 */
+	public function __invoke( $args, $assoc_args ) {
+		// Get the filename to import.
+		list( $import_filename ) = $args;
+
+		// Is the file empty?
+		if ( empty ( $import_filename ) ) {
+			\WP_CLI::error( __( 'You must specify a valid file to import.', 'toolset-cli' ) );
+		}
+
+		// Does the import file exist?
+		if ( ! file_exists ( $import_filename ) ) {
+			\WP_CLI::error( sprintf ( __( '"%s" does not exist. Aborting.' ), $import_filename), 'toolset-cli' );
+		}
+
+		// Returns filename extension without a period prefixed to it.
+		$import_filename_extension = pathinfo( $import_filename, PATHINFO_EXTENSION );
+
+		// Does the file have a ".zip" extension?
+		if ( ! $import_filename_extension || strtolower ( $import_filename_extension ) != 'zip' ) {
+			\WP_CLI::error( sprintf ( __( '"%s" is not in ZIP format.'), $import_filename), 'toolset-cli' );
+		}
+
+		// Load the import code from the Layouts plugin.
+		require_once WPDDL_ABSPATH . '/inc/theme/wpddl.theme-support.class.php' ;
+
+		$layouts = new WPDD_Layouts_Theme () ;
+		// Trying to remove shut_down_handler because of this error:
+		// "The Layouts files you are trying to upload are too big and you ran out of memory..."
+		// remove_action('toolset-shutdown-hander', array(&$layouts, 'shut_down_handler'));
+
+		// Array of arguments to pass to import_layouts() method.
+		$import_args = array() ;
+
+		// Parse command-line options and add to $import_args[].
+		if ( count ( $assoc_args ) > 0 ) {
+			foreach ( $assoc_args as $option => $value ) {
+				// We ignore the $value. The presence of the element is enough.
+				$import_args[$option] = true ;
+			}
+		}
+
+		// Returns filename without the path to the parent directory.
+		$import_filename_basename = pathinfo( $import_filename, PATHINFO_BASENAME );
+
+		// Create an array that holds the properties of the $_FILES array for compatibility with manage_manual_import() method.
+		$files = [] ;
+		$files['import-file']['name'] = $import_filename_basename ; // basename
+		$files['import-file']['tmp_name'] = $import_filename ; // full path
+
+		// Flag to track the import status.
+		$import_status = false ;
+
+		$import_status = $layouts->import_layouts( $files, $import_args );
+
+		if ( $import_status === true ) {
+			\WP_CLI::success( sprintf ( __( 'The layouts were imported successfully from "%s."'), $import_filename ) , 'toolset-cli' );
+		} else {
+			\WP_CLI::error( __( 'There was an error importing the layouts.', 'toolset-cli' ) );
+		}
+
+	}
+
+}

--- a/application/Commands/Layouts/Import.php
+++ b/application/Commands/Layouts/Import.php
@@ -4,14 +4,10 @@ namespace OTGS\Toolset\CLI\Layouts;
 
 use WPDD_Layouts_Theme ;
 
-/*
- * FIXME: replace \WP_CLI with WpCli.
- */
-
 /**
  * Layouts import command.
  */
-class LayoutsImport extends LayoutsCommand {
+class Import extends LayoutsCommand {
 
 	/**
 	 * Imports Layouts from a ZIP file.
@@ -46,12 +42,12 @@ class LayoutsImport extends LayoutsCommand {
 
 		// Is the file empty?
 		if ( empty ( $import_filename ) ) {
-			\WP_CLI::error( __( 'You must specify a valid file to import.', 'toolset-cli' ) );
+			$this->wp_cli()->error( __( 'You must specify a valid file to import.', 'toolset-cli' ) );
 		}
 
 		// Does the import file exist?
 		if ( ! file_exists ( $import_filename ) ) {
-			\WP_CLI::error( sprintf ( __( '"%s" does not exist. Aborting.' ), $import_filename), 'toolset-cli' );
+			$this->wp_cli()->error( sprintf ( __( '"%s" does not exist. Aborting.' ), $import_filename), 'toolset-cli' );
 		}
 
 		// Returns filename extension without a period prefixed to it.
@@ -59,16 +55,13 @@ class LayoutsImport extends LayoutsCommand {
 
 		// Does the file have a ".zip" extension?
 		if ( ! $import_filename_extension || strtolower ( $import_filename_extension ) != 'zip' ) {
-			\WP_CLI::error( sprintf ( __( '"%s" is not in ZIP format.'), $import_filename), 'toolset-cli' );
+			$this->wp_cli()->error( sprintf ( __( '"%s" is not in ZIP format.'), $import_filename), 'toolset-cli' );
 		}
 
 		// Load the import code from the Layouts plugin.
 		require_once WPDDL_ABSPATH . '/inc/theme/wpddl.theme-support.class.php' ;
 
 		$layouts = new WPDD_Layouts_Theme () ;
-		// Trying to remove shut_down_handler because of this error:
-		// "The Layouts files you are trying to upload are too big and you ran out of memory..."
-		// remove_action('toolset-shutdown-hander', array(&$layouts, 'shut_down_handler'));
 
 		// Array of arguments to pass to import_layouts() method.
 		$import_args = array() ;
@@ -89,15 +82,12 @@ class LayoutsImport extends LayoutsCommand {
 		$files['import-file']['name'] = $import_filename_basename ; // basename
 		$files['import-file']['tmp_name'] = $import_filename ; // full path
 
-		// Flag to track the import status.
-		$import_status = false ;
+		$import_succeeded = $layouts->import_layouts( $files, $import_args );
 
-		$import_status = $layouts->import_layouts( $files, $import_args );
-
-		if ( $import_status === true ) {
-			\WP_CLI::success( sprintf ( __( 'The layouts were imported successfully from "%s."'), $import_filename ) , 'toolset-cli' );
+		if ( $import_succeeded ) {
+			$this->wp_cli()->success( sprintf ( __( 'The layouts were imported successfully from "%s."'), $import_filename ) , 'toolset-cli' );
 		} else {
-			\WP_CLI::error( __( 'There was an error importing the layouts.', 'toolset-cli' ) );
+			$this->wp_cli()->error( __( 'There was an error importing the layouts.', 'toolset-cli' ) );
 		}
 
 	}

--- a/application/Commands/Layouts/LayoutsCommand.php
+++ b/application/Commands/Layouts/LayoutsCommand.php
@@ -9,13 +9,4 @@ use OTGS\Toolset\CLI\Commands\ToolsetCommand;
  */
 abstract class LayoutsCommand extends ToolsetCommand {
 
-	/**
-	 * Constructor.
-	 * FIXME: do we need this?
-	 */
-	public function __construct() {
-		parent::__construct();
-
-	}
-
 }

--- a/application/Commands/Layouts/LayoutsCommands.php
+++ b/application/Commands/Layouts/LayoutsCommands.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace OTGS\Toolset\CLI\Layouts;
+
+use OTGS\Toolset\CLI\Commands\ToolsetCommand;
+
+/**
+ * The base class for Layouts commands.
+ */
+abstract class LayoutsCommand extends ToolsetCommand {
+
+	/**
+	 * Constructor.
+	 * FIXME: do we need this?
+	 */
+	public function __construct() {
+		parent::__construct();
+
+	}
+
+}

--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -1,0 +1,7 @@
+# wp layouts
+
+Layouts commands.
+
+## Subcommands
+
+- [wp layouts export](layouts/export.md) \[--overwrite] <file>

--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -5,3 +5,4 @@ Layouts commands.
 ## Subcommands
 
 - [wp layouts export](layouts/export.md) \[--overwrite] <file>
+- [wp layouts import](layouts/import.md) \[--layouts-overwrite] \[--layouts-delete] \[--overwrite-layouts-assignment]<file>

--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -5,4 +5,4 @@ Layouts commands.
 ## Subcommands
 
 - [wp layouts export](layouts/export.md) \[--overwrite] <file>
-- [wp layouts import](layouts/import.md) \[--layouts-overwrite] \[--layouts-delete] \[--overwrite-layouts-assignment]<file>
+- [wp layouts import](layouts/import.md) \[--layouts-overwrite] \[--layouts-delete] \[--overwrite-layouts-assignment] <file>

--- a/docs/layouts/export.md
+++ b/docs/layouts/export.md
@@ -1,6 +1,6 @@
 # wp layouts export
 
-Exports a Layouts XML file.
+Exports a Layouts ZIP file.
 
 ### Options
 
@@ -8,7 +8,7 @@ Exports a Layouts XML file.
 : Overwrite &lt;file&gt; if it exists
 
 &lt;file&gt;
-: The XML file to export.
+: The ZIP file to export.
 
 ### EXAMPLES
 

--- a/docs/layouts/export.md
+++ b/docs/layouts/export.md
@@ -1,0 +1,17 @@
+# wp layouts export
+
+Exports a Layouts XML file.
+
+### Options
+
+[\--overwrite]
+: Overwrite &lt;file&gt; if it exists
+
+&lt;file&gt;
+: The XML file to export.
+
+### EXAMPLES
+
+    wp layouts export <file>
+    wp layouts export --overwrite <file>
+

--- a/docs/layouts/import.md
+++ b/docs/layouts/import.md
@@ -1,0 +1,22 @@
+# wp layouts import
+
+Imports a Layouts XML file.
+
+### OPTIONS
+
+[\--layouts-overwrite]
+: Overwrite any layout if it already exists.
+
+[\--layouts-delete]
+: Delete any existing layouts that are not in the import.
+
+[\--overwrite-layouts-assignment]
+: Overwrite layout assignments.
+
+&lt;file&gt;
+: The XML file to import.
+
+### EXAMPLES
+
+    wp layouts import <file>
+

--- a/docs/layouts/import.md
+++ b/docs/layouts/import.md
@@ -1,6 +1,6 @@
 # wp layouts import
 
-Imports a Layouts XML file.
+Imports a Layouts ZIP file.
 
 ### OPTIONS
 
@@ -14,7 +14,7 @@ Imports a Layouts XML file.
 : Overwrite layout assignments.
 
 &lt;file&gt;
-: The XML file to import.
+: The ZIP file to import.
 
 ### EXAMPLES
 


### PR DESCRIPTION
A few notes:

+ The code may not be organized the way you wish it to be organized. I ended up adding two new classes in two new files corresponding to the import and export commands, but it may be more desirable to combine them into a single file.

+ I added a third new class / file, `application/Commands/Layouts/LayoutsCommands.php`, which has a constructor. I don't know whether the constructor method is necessary.

+ I didn't know how to use the recommended WpCli class, so I didn't. If you can provide instructions or an example, I will happily update my code.

+ I didn't know how to load the PHPCS Toolset coding standards, so I didn't. If you can provide instructions, I will happily update my code.

+ The export command includes an "--overwrite" flag that the views import command lacked (but that @zaantar added).

+ The code will not work until the layouts plugin is updated. Specifically, two files need to be revised:
\_\_`layouts/classes-auto/wpddl-options.class.php` [see the comments in issue 6 re: the needed revision](https://github.com/OnTheGoSystems/toolset-cli/issues/6)
\_\_`layouts/inc/theme/wpddl.theme-support.class.php` [view a patch](https://gist.github.com/baizmandesign/8d56f459f02ed4842402142449db13ae)

+ Once merged, issue #6 can be closed.