### PR TITLE
Added views import and export zip format support

### DIFF
--- a/application/Commands/views/Export.php
+++ b/application/Commands/views/Export.php
@@ -2,15 +2,26 @@
 
 namespace OTGS\Toolset\CLI\Views;
 
+use ZipArchive;
+
 class Export extends Views_Commands {
 
+
+	const EXPORT_FORMAT_ZIP = 'zip';
+
+	const EXPORT_FORMAT_XML = 'xml';
+
+
 	/**
-	 * Exports Views to a zip file.
+	 * Export Views to an XML or ZIP file.
 	 *
 	 * ## Options
 	 *
 	 * <file>
 	 * : The filename of the exported file.
+	 *
+	 * [--format=<zip|xml>]
+	 * : The format can be either "zip" or "xml". If omitted, the default is xml.
 	 *
 	 * [--overwrite]
 	 * : Allow for overwriting an existing file.
@@ -18,41 +29,99 @@ class Export extends Views_Commands {
 	 * ## Examples
 	 *
 	 *     wp views export file
+	 *     wp views export --overwrite --format=zip file
 	 *
-	 * @synopsis <file> [--overwrite]
+	 * @synopsis [--overwrite] [--format=<zip|xml>] <file>
 	 *
-	 * @param array $args The arguments of the post type query.
-	 * @param array $assoc_args The associative arguments of the post type query.
+	 * @param array $args The array of command-line arguments.
+	 * @param array $assoc_args The associative array of command-line options.
 	 */
 	public function __invoke( $args, $assoc_args ) {
 		list( $export_filename ) = $args;
 
 		if ( empty ( $export_filename ) ) {
-			\WP_CLI::warning( __( 'You must specify a valid file.', 'toolset-cli' ) );
+			$this->wp_cli()->warning( __( 'You must specify a valid file.', 'toolset-cli' ) );
 
 			return;
 		}
 
+		// The default exported format is XML.
+		$export_file_format = self::EXPORT_FORMAT_XML;
+
+		// Was the --format option specified on the command line?
+		if ( array_key_exists( 'format', $assoc_args ) ) {
+
+			switch ( strtolower( $assoc_args['format'] ) ) {
+				case self::EXPORT_FORMAT_ZIP:
+					$export_file_format = self::EXPORT_FORMAT_ZIP;
+					break;
+				case self::EXPORT_FORMAT_XML:
+					// Do nothing, this is the default format.
+					break;
+				default:
+					// For any other format, quit.
+					$this->wp_cli()
+						->error( sprintf( __( '"%s" is not a valid export format. Aborting.', 'toolset-cli' ), strtolower( $assoc_args['format'] ) ) );
+
+			}
+		}
+
+		// Returns filename extension without a period prefixed to it.
+		$export_filename_extension = pathinfo( $export_filename, PATHINFO_EXTENSION );
+
+		// Does the specified filename have an extension? If not, add it and notify the user.
+		if ( ! $export_filename_extension || strtolower( $export_filename_extension ) !== $export_file_format ) {
+
+			// Returns filename without the path to the parent directory.
+			$export_filename_basename = pathinfo( $export_filename, PATHINFO_BASENAME );
+
+			$this->wp_cli()
+				->warning( __( sprintf( '"%1$s" lacks a "%2$s" extension. Adding it. The new filename will be "%1$s.%2$s."', $export_filename_basename, $export_file_format ), 'toolset-cli' ) );
+
+			// Append appropriate extension to export filename.
+			$export_filename .= sprintf( '.%s', $export_file_format );
+		}
+
 		// Warn if the file already exists.
 		if ( ! array_key_exists( 'overwrite', $assoc_args ) && is_file( $export_filename ) ) {
-			\WP_CLI::warning( sprintf( __( '"%s" already exists. Exiting.', 'toolset-cli' ), $export_filename ) );
-
-			return;
+			$this->wp_cli()
+				->error( sprintf( __( '"%s" already exists. Aborting.', 'toolset-cli' ), $export_filename ) );
 		}
 
 		require_once WPV_PATH . '/inc/wpv-import-export.php';
 
 		$exported_data = wpv_admin_export_data( false );
 
-		$written_bytes = file_put_contents( $export_filename, $exported_data );
+		if ( $export_file_format === self::EXPORT_FORMAT_ZIP ) {
+			// Create Zip archive.
+			$export_file_zip_data = new ZipArchive;
+			$result = $export_file_zip_data->open( $export_filename, ZipArchive::CREATE );
+			if ( $result === true ) {
 
-		if ( ! $written_bytes ) {
-			\WP_CLI::error( __( 'There was an error while exporting the views.', 'toolset-cli' ) );
+				$export_file_zip_data->addFromString( 'settings.xml', $exported_data );
+				// A file named "settings.php" is exported via the GUI. It just contains a timestamp.
+				$settings = sprintf( '<?php $timestamp = %s; ?>', time() );
+				$export_file_zip_data->addFromString( 'settings.php', $settings );
+				if ( ! $export_file_zip_data->close() ) {
+					$this->wp_cli()->error( __( 'There was an error saving the views to a ZIP file.', 'toolset-cli' ) );
+				}
+			} else {
+				$this->wp_cli()->error( __( 'There was an error exporting the views to a ZIP file.', 'toolset-cli' ) );
+			}
 
-			return;
+		} else {
+			// We're only writing an XML file.
+			$written_bytes = file_put_contents( $export_filename, $exported_data );
+
+			if ( ! $written_bytes ) {
+				$this->wp_cli()->error( __( 'There was an error exporting the views to an XML file.', 'toolset-cli' ) );
+
+				return;
+			}
 		}
 
-		\WP_CLI::success( sprintf( __( 'The views were exported successfully to "%s".', 'toolset-cli' ), $export_filename ) );
+		$this->wp_cli()
+			->success( sprintf( __( 'The views were exported successfully to "%s".', 'toolset-cli' ), $export_filename ) );
 	}
 
 }

--- a/docs/views.md
+++ b/docs/views.md
@@ -3,7 +3,7 @@
 ## Subcommands
 
 - [wp views archive](views/archive.md) &lt;command&gt;
-- [wp views export](views/export.md) &lt;file&gt;
+- [wp views export](views/export.md) \[--overwrite] \[--format=&lt;zip|xml&gt;] &lt;file&gt;
 - [wp views import](views/import.md) \[--views-overwrite] \[--views-delete] \[--view-templates-overwrite] \[--view-templates-delete] \[--view-settings-overwrite] &lt;file&gt;
 - [wp views template](views/template.md) &lt;command&gt;
 - [wp views view](views/view.md) &lt;command&gt;

--- a/docs/views/export.md
+++ b/docs/views/export.md
@@ -1,16 +1,19 @@
 # wp views export
 
-Exports a Types XML file.
+Exports a Views XML or ZIP file.
 
 ### Options
 
+[\--format=<zip|xml>]
+: The format can be either "zip" or "xml". If omitted, the default is xml.
+
+[\--overwrite]
+: Allow for overwriting an existing file.
+
 &lt;file&gt;
-: The XML file to export.
+: The XML or ZIP file to export.
 
 ### Examples
 
     wp views export <file>
-
-### Additional Notes
-
-If &lt;file&gt; already exists, it will not be over-written and the program will abort.
+    wp views export --overwrite --format=zip <file>

--- a/docs/views/export.md
+++ b/docs/views/export.md
@@ -5,7 +5,7 @@ Exports a Views XML or ZIP file.
 ### Options
 
 [\--format=<zip|xml>]
-: The format can be either "zip" or "xml". If omitted, the default is xml.
+: The format can be either "zip" or "xml". If omitted, it will be inferred from the file extension.
 
 [\--overwrite]
 : Allow for overwriting an existing file.

--- a/docs/views/import.md
+++ b/docs/views/import.md
@@ -1,6 +1,6 @@
 # wp views import
 
-Imports a Types XML file.
+Imports a Views XML or ZIP file.
 
 ### Options
 
@@ -20,7 +20,7 @@ Imports a Types XML file.
 : Overwrite Views settings.
 
 &lt;file&gt;
-: The XML file to import.
+: The XML or ZIP file to import.
 
 ### Examples
 


### PR DESCRIPTION
This is for issue #5.

Is the `[--format=<zip|xml>]` notation correct for command-line options?

This PR does not accommodate theme designers who, on the GUI, check off "I am a theme designer and I want to receive affiliate commission" during export.

Sidenote: I used the ZipArchive class in my code. The Toolset code in the Views plugin uses zip_* functions, which are deprecated.